### PR TITLE
Fixed mac-address gets "is empty".

### DIFF
--- a/mac-address.hpp
+++ b/mac-address.hpp
@@ -28,6 +28,10 @@ std::map<std::string, std::string> decodeMacAddressConfig(void)
     {
         while (getline(confFile, line))
         {
+            if (line.size() == 0)
+            {
+                continue;
+            }
             size_t num = 0;
             num = line.find_first_of("=");
             std::string item = line.substr(0, num);


### PR DESCRIPTION
When the config file use additional new line, mac-address thinks this is
config getting corrupted.

Solution: Add a if-statement to decodeMacAddressConfig.

Tested by using config file: 
[result.txt](https://github.com/quanta-bmc/mac-address/files/5923863/result.txt)