### PR TITLE
Filter some probed fail fru device

### DIFF
--- a/scripts/find-fru-bus.sh
+++ b/scripts/find-fru-bus.sh
@@ -3,6 +3,25 @@
 confPath=/usr/share/mac-address
 confFilename=config.txt
 
+of_name_to_eeproms() {
+  local names
+  if ! names="$(grep -xl "$1" /sys/bus/i2c/devices/*/of_node/name)"; then
+    echo "Failed to find eeproms with of_name '$1'" >&2
+    return 1
+  fi
+  names=$(echo "$names" | sed 's,/of_node/name$,/eeprom,')
+  if (( "$(echo "$names" | wc -l)" != 1 )); then
+    for path in ${names[@]}
+    do
+        if [ -f "$path" ]; then
+          exist_path="$exist_path $path"
+        fi
+    done
+    names=$exist_path
+  fi
+  eval echo "$names"
+}
+
 #check config file
 if [ ! -f "${confPath}/${confFilename}" ]; then
     exit 0
@@ -14,7 +33,7 @@ if [ -z "${configTargetName}" ]; then
 fi
 
 targetName="${configTargetName#*eeprom=}"
-targetPath=$(grep -xl "${targetName}" /sys/bus/i2c/devices/*/of_node/name)
+targetPath=$(of_name_to_eeproms "${targetName}")
 
 # Get target i2c number
 if [ -n "${targetPath}" ]; then


### PR DESCRIPTION
Need to support the same fru device node name
but different address in multiple stage, so we
need to filter some eeprom probed fail but the
device node name is the same.

Signed-off-by: Duke Du <Duke.Du@quantatw.com>