### PR TITLE
Fix build warning for unused result with system()

### DIFF
--- a/mac-address.hpp
+++ b/mac-address.hpp
@@ -96,10 +96,19 @@ void writeMacAddress(const std::string& port, std::string* macAddress)
     }
     else
     {
-        std::system(("ip link set " +  port + " down").c_str());
-        std::system(
-            ("ip link set " +  port + " address " + *macAddress).c_str());
-        std::system(("ip link set " +  port + " up").c_str());
+        if(std::system(("ip link set " +  port + " down").c_str())){
+            std::cerr << "Failed to run ip link set " <<  port <<
+                " down" << '\n';
+        }
+        if(std::system(("ip link set " +  port + " address " +
+            *macAddress).c_str())) {
+            std::cerr << "Failed to run ip link set " <<  port <<
+                " address" << '\n';
+        }
+        if (std::system(("ip link set " +  port + " up").c_str())){
+            std::cerr << "Failed to run ip link set " <<  port <<
+                " up" << '\n';
+        }
     }
     return;
 }


### PR DESCRIPTION
```
| ../git/mac-address.hpp:132:20: warning: ignoring return value of 'int system(const char*)' declared with attribute 'warn_unused_result' [-Wunused-result]
|   132 |         std::system(("ip link set " +  port + " down").c_str());
|       |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| ../git/mac-address.hpp:133:20: warning: ignoring return value of 'int system(const char*)' declared with attribute 'warn_unused_result' [-Wunused-result]
|   133 |         std::system(("ip link set " +  port + " address " + *macAddress).c_str());
|       |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| ../git/mac-address.hpp:134:20: warning: ignoring return value of 'int system(const char*)' declared with attribute 'warn_unused_result' [-Wunused-result]
|   134 |         std::system(("ip link set " +  port + " up").c_str());
|       |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```