### PR TITLE
include cstdint for uint8_t

### DIFF
--- a/mac-address.hpp
+++ b/mac-address.hpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <sstream>
 #include <iomanip>
+#include <cstdint>
 #include <cstdlib>
 #include <ctime>
 #include <fstream>


### PR DESCRIPTION
With gcc13 the repo does not build due to missing uint8_t definition